### PR TITLE
Unw single image edits

### DIFF
--- a/LOOPY_bin/LOOPY01_find_errors.py
+++ b/LOOPY_bin/LOOPY01_find_errors.py
@@ -267,7 +267,7 @@ def main(argv=None):
             mli = np.log10(coh)
             vmin = np.nanpercentile(mli, 5)
             vmax = np.nanpercentile(mli, 95)
-            plot_lib.make_im_png(mli, mlipngfile, 'gray', 'MLI (log10)', vmin, vmax, cbar=True)
+            plot_lib.make_im_png(mli, mlipngfile, 'gray', 'MLI (log10)', vmin=vmin, vmax=vmax, cbar=True)
             print('  slc.mli[.png] created', flush=True)
             ref_type = 'MLI'
         else:
@@ -329,7 +329,7 @@ def main(argv=None):
         if fullres:
             bool_plot = tools_lib.multilook(bool_plot, ml_factor, ml_factor, 0.1)
         title = 'Known UNW error Locations)'
-        plot_lib.make_im_png(bool_plot, os.path.join(corrdir, 'known_errors.png'), 'viridis', title, 0, 1, cbar=False)
+        plot_lib.make_im_png(bool_plot, os.path.join(corrdir, 'known_errors.png'), 'viridis', title, vmin=0, vmax=1, cbar=False)
         print('Map of known error locations made')
 
     # Find reference pixel. If none provided, use highest coherence pixel
@@ -603,11 +603,11 @@ def mask_unw_errors(i):
     if i == v:
         pltpi = npi.copy()
         pltpi[np.where(errors == 1)] = 10
-        plot_lib.make_im_png(pltpi, os.path.join(corrdir, date, date + '.checkaim.png'), 'tab20c', 'Check Aim', -1, 10, cbar=False)
+        plot_lib.make_im_png(pltpi, os.path.join(corrdir, date, date + '.checkaim.png'), 'tab20c', 'Check Aim', vmin=-1, vmax=10, cbar=False)
 
     # %% Multilook mask if required
     if fullres:
-        unw = tools_lib.multilook(unw, ml_factor, ml_factor, 0.1)
+        unw = tools_lib.multilook(unw, ml_factor, ml_factor, 0.5)
         if i == v:
             print('        Original IFG multilooked {:.2f}'.format(time.time() - begin))
         mask = tools_lib.multilook(mask, ml_factor, ml_factor, 0.1).astype('bool').astype('int')
@@ -632,7 +632,7 @@ def mask_unw_errors(i):
     mask = (mask == 0).astype('int')
     mask[np.where(np.isnan(unw))] = 0
     title = '{} ({}pi/cycle)'.format(date, 3 * 2)
-    plot_lib.make_im_png(np.angle(np.exp(1j * corr_unw / 3) * 3), os.path.join(corrdir, date, date + '.unw.png'), SCM.romaO, title, -np.pi, np.pi, cbar=False)
+    plot_lib.make_im_png(np.angle(np.exp(1j * corr_unw / 3) * 3), os.path.join(corrdir, date, date + '.unw.png'), SCM.romaO, title, vmin=-np.pi, vmax=np.pi, cbar=False)
     # Make new unw file from corrected data and new loop png
     corr_unw.tofile(os.path.join(corrdir, date, date + '.unw'))
     mask.astype('bool').tofile(os.path.join(corrdir, date, date + '.mask'))
@@ -645,7 +645,7 @@ def mask_unw_errors(i):
     loopy_lib.make_compare_png(unw, corr_unw, npi, correction / (2 * np.pi), corrcomppng, titles4, 3)
 
     title = 'Error Map'
-    plot_lib.make_im_png(errors, os.path.join(corrdir, date, date + '.errormap.png'), 'viridis', title, 0, 1, cbar=False)
+    plot_lib.make_im_png(errors, os.path.join(corrdir, date, date + '.errormap.png'), 'viridis', title, vmin=0, vmax=1, cbar=False)
 
     if i == v:
         print('        pngs made {:.2f}'.format(time.time() - begin))


### PR DESCRIPTION
Edits made because I noticed that on uncorrected IFGs, the unw.pngs were very different between original and loopy IFG.
Thought this was just a plotting issue, but it was a result of the multi-looking used (I was using an unw_thresh of 0.1, vs 0.5 in LiCSBAS). Have changed this now so that the same ML thresholds are used.

Side benefit could be that a low threshold was allowing more bad pixels through (good pixels generally seemed to be occurring in a high enough densty anyway, that although more were being allowed through, the increase wasn't to the same amount) , and this could mean that fewer IFGs are selected. Increasing to be in line with LiCSBAS should mean that more corrected IFGs are accepted